### PR TITLE
Fix minor grammatical error: loose -> lose

### DIFF
--- a/littlenavmap_de.ts
+++ b/littlenavmap_de.ts
@@ -192,7 +192,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation>Leistungsdatenerfassung stoppen und aktuelle Werte verlieren?</translation>
     </message>
     <message>

--- a/littlenavmap_es.ts
+++ b/littlenavmap_es.ts
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/littlenavmap_fr.ts
+++ b/littlenavmap_fr.ts
@@ -196,7 +196,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation type="unfinished">Réinitialiser la collecte des performances et perdre toutes les valeurs actuelles ?</translation>
     </message>
     <message>

--- a/littlenavmap_it.ts
+++ b/littlenavmap_it.ts
@@ -288,7 +288,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation>Ripristinare la raccolta delle prestazioni e perdere tutti i valori correnti?</translation>
     </message>
     <message>

--- a/littlenavmap_nl.ts
+++ b/littlenavmap_nl.ts
@@ -196,7 +196,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/littlenavmap_pt_BR.ts
+++ b/littlenavmap_pt_BR.ts
@@ -192,7 +192,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation>Resetar a coleção de perfomance e perder todos os valores atuais?</translation>
     </message>
     <message>

--- a/littlenavmap_zh.ts
+++ b/littlenavmap_zh.ts
@@ -49,7 +49,7 @@
     </message>
     <message>
         <location filename="src/perf/aircraftperfcontroller.cpp" line="229"/>
-        <source>Reset performance collection and loose all current values?</source>
+        <source>Reset performance collection and lose all current values?</source>
         <translation>重置性能收集并丢弃所有现有值？</translation>
     </message>
     <message>

--- a/src/mapgui/mapwidget.cpp
+++ b/src/mapgui/mapwidget.cpp
@@ -444,7 +444,7 @@ void MapWidget::showTooltip(bool update)
     hideTooltip();
 }
 
-/* Stop all line drag and drop if the map looses focus */
+/* Stop all line drag and drop if the map loses focus */
 void MapWidget::focusOutEvent(QFocusEvent *)
 {
   hideTooltip();

--- a/src/perf/aircraftperfcontroller.cpp
+++ b/src/perf/aircraftperfcontroller.cpp
@@ -226,7 +226,7 @@ void AircraftPerfController::restartCollection(bool quiet)
   if(!quiet)
     result = atools::gui::Dialog(mainWindow).
              showQuestionMsgBox(lnm::ACTIONS_SHOW_RESET_PERF,
-                                tr("Reset performance collection and loose all current values?"),
+                                tr("Reset performance collection and lose all current values?"),
                                 tr("Do not &show this dialog again."),
                                 QMessageBox::Yes | QMessageBox::No,
                                 QMessageBox::No, QMessageBox::Yes);


### PR DESCRIPTION
Something is said to be _loose_ if it is not affixed tightly.  e.g.: _Helen held onto her journal loosely, watching its papers flutter in the breeze._

To _lose_ something is to misplace it.  e.g.: _John was beginning to lose his mind._  _We lost sight of the target_.