### PR TITLE
enable Android pinch zoom and use functionality for it cross-device, …

### DIFF
--- a/web/assets/styles-2021-a-look-internal.css
+++ b/web/assets/styles-2021-a-look-internal.css
@@ -29,6 +29,12 @@
   width: 150px;
 }
 
+@media (max-width: 374px) {
+  .toolbar button {
+     width: 125px;
+  }
+}
+
 .toolbar button a {
   text-decoration: none;
   color: inherit;


### PR DESCRIPTION
…make better use of "small" device widths space for outer ui buttons, accompany settable fast map refresh quality with settable fast map refresh interval value

@albar965 I used a ~ 9 year old event for pinch zoom detection which I didn't check compatibility tables for. It still is only supported on iOS devices. I replaced it in this branch with a cross-device solution, tested on iOS Safari, Chromium and Android Chrome. With this update I also update outer ui buttons width for "small" screen widths (making them 2 column instead of 1 on eg. "old" Android phones) and make a value easier settable.