### PR TITLE
Hint at escaping spaces in Linux .desktop file example

### DIFF
--- a/desktop/Little Navmap.desktop
+++ b/desktop/Little Navmap.desktop
@@ -1,9 +1,11 @@
 [Desktop Entry]
 Type=Application
-Exec=YOUR_PATH_TO_LITTLENAVMAP/littlenavmap
+Exec='YOUR_PATH_TO_LITTLENAVMAP/littlenavmap'
+# replace spaces with \s
 Path=YOUR_PATH_TO_LITTLENAVMAP/
 Name=Little Navmap
 GenericName=Little Navmap
+# replace spaces with \s
 Icon=YOUR_PATH_TO_LITTLENAVMAP/littlenavmap.svg
 Terminal=false
 Categories=Qt;Utility;Geography;Maps;


### PR DESCRIPTION
In a default download and install, one has to deal with spaces in paths
for the Freedesktop .desktop file.

This can cause some grief so I propose to add that to the example.

The specs can be found here:
https://specifications.freedesktop.org/desktop-entry-spec/latest/

---

I have just begun using this program but I am totally impressed already. Thank you! 