### PR TITLE
extended web API slightly, changed map navigation to click becomes ce…

### DIFF
--- a/src/common/infobuildertypes.h
+++ b/src/common/infobuildertypes.h
@@ -86,6 +86,8 @@ namespace InfoBuilderTypes {
         const int zoomWeb;
         const qreal distanceUi;
         const qreal distanceWeb;
+        const float latLonRectUi[4];
+        const float latLonRectWeb[4];
     };
 
     /**

--- a/src/common/jsoninfobuilder.cpp
+++ b/src/common/jsoninfobuilder.cpp
@@ -321,14 +321,14 @@ QByteArray JsonInfoBuilder::uiinfo(UiInfoData uiInfoData) const
 
     UiInfoData data = uiInfoData;
 
-    JSON json;
-
-       json = {
-           { "zoom_ui", data.zoomUi},
-           { "zoom_web", data.zoomWeb},
-           { "distance_ui", data.distanceUi},
-           { "distance_web", data.distanceWeb},
-       };
+    JSON json = {
+      { "zoom_ui", data.zoomUi},
+      { "zoom_web", data.zoomWeb},
+      { "distance_ui", data.distanceUi},
+      { "distance_web", data.distanceWeb},
+      { "latLonRect_ui", data.latLonRectUi},
+      { "latLonRect_web", data.latLonRectWeb}
+    };
 
     return json.dump().data();
 }

--- a/src/web/requesthandler.cpp
+++ b/src/web/requesthandler.cpp
@@ -231,6 +231,14 @@ inline void RequestHandler::handleMapImage(HttpRequest& request, HttpResponse& r
       // Show an airport by ident
       mapPixmap = emit getPixmapObject(width, height, web::AIRPORT, params.asStr(
                                          QStringLiteral(u"airport")).toUpper(), requestedDistanceKm);
+    else if(mapcmd == QLatin1String("center"))
+    {
+      // Center map around given postion
+      atools::geo::Pos pos(0.0, 0.0);
+      pos.setLonX(params.asFloat(QStringLiteral(u"lon")));
+      pos.setLatY(params.asFloat(QStringLiteral(u"lat")));
+      mapPixmap = emit getPixmapPosDistance(width, height, pos, requestedDistanceKm, QLatin1String(""));
+    }
     else
     {
       // When zooming in or out use the last corrected distance (i.e. actual distance) as a base

--- a/src/webapi/uiactionscontroller.cpp
+++ b/src/webapi/uiactionscontroller.cpp
@@ -21,15 +21,23 @@ Q_UNUSED(request)
     if(verbose)
         qDebug() << Q_FUNC_INFO;
 
-    // Get a new response object
-    WebApiResponse response = getResponse();
+    MapWidget *mw = getMainWindow()->getMapWidget();
+    MapPaintWidget *mpw = NavApp::getMapPaintWidgetWeb();
+
+    atools::geo::Rect ru = mw->getCurrentViewRect();
+    atools::geo::Rect rw = mpw->getCurrentViewRect();
 
     UiInfoData data = {
-        getMainWindow()->getMapWidget()->zoom(),
-        NavApp::getMapPaintWidgetWeb()->zoom(),
-        getMainWindow()->getMapWidget()->distance(),
-        NavApp::getMapPaintWidgetWeb()->distance()
+        mw->zoom(),
+        mpw->zoom(),
+        mw->distance(),
+        mpw->distance(),
+        {ru.getNorth(), ru.getEast(), ru.getSouth(), ru.getWest()},
+        {rw.getNorth(), rw.getEast(), rw.getSouth(), rw.getWest()}
     };
+
+    // Get a new response object
+    WebApiResponse response = getResponse();
 
     response.body = infoBuilder->uiinfo(data);
     response.status = 200;

--- a/web/javascript_and_css/2021-a/map.css
+++ b/web/javascript_and_css/2021-a/map.css
@@ -125,6 +125,10 @@ body {
   opacity: 0;
 }
 
+#map {
+  cursor: crosshair;
+}
+
 #interactionParent:has(.transition) {
   overflow: hidden;
 }

--- a/web/javascript_and_css/2021-a/scripts.js
+++ b/web/javascript_and_css/2021-a/scripts.js
@@ -194,7 +194,7 @@ function injectUpdates(origin) {
     /*
      * Event handling: mousemove over map (parent)
      */
-    mapElement.parentElement.onmousemove = function(e) {
+    /*mapElement.parentElement.onmousemove = function(e) {
       var s = e.currentTarget.clientHeight / e.currentTarget.clientWidth;
       var x = e.offsetX - e.currentTarget.clientWidth / 2;
       var y = -(e.offsetY - e.currentTarget.clientHeight / 2);
@@ -211,14 +211,28 @@ function injectUpdates(origin) {
           e.currentTarget.setAttribute("data-shift", "down");       // south
         }
       }
-    };
+    };*/
 
     /*
      * Event handling: click map
      */
+    var notGettingMapViewRect = true;
     ocw.handleInteraction = function(e) {
-      var shift = e.currentTarget.getAttribute("data-shift");
-      shift !== null ? updateMapImage("mapcmd=" + shift + "&cmd", defaultMapQuality, true) : 0;         // on touch devices, without initial HTML attribute, shift === null when pinching for zoom in
+      /*var shift = e.currentTarget.getAttribute("data-shift");
+      shift !== null ? updateMapImage("mapcmd=" + shift + "&cmd", defaultMapQuality, true) : 0;*/         // on touch devices, without initial HTML attribute, shift === null when pinching for zoom in
+      if(notGettingMapViewRect) {
+        notGettingMapViewRect = false;
+        fetch("/api/ui/info").then(response => response.json(), error => {
+          console?.log(error);
+          notGettingMapViewRect = true;
+        }).then(json => {
+          updateMapImage("mapcmd=center&lon=" + (json.latLonRect_web[3] + (json.latLonRect_web[1] - json.latLonRect_web[3]) * (e.offsetX / mapElement.clientWidth)) + "&lat=" + (json.latLonRect_web[0] + (json.latLonRect_web[2] - json.latLonRect_web[0]) * (e.offsetY / mapElement.clientHeight)) + "&cmd", defaultMapQuality, true);
+          notGettingMapViewRect = true;
+        }, error => {
+          console?.log(error);
+          notGettingMapViewRect = true;
+        });
+      }
     };
 
     /*

--- a/web/webapi.yaml
+++ b/web/webapi.yaml
@@ -534,6 +534,14 @@ components  :
           description         : the distance value of the map inside LNM Web UI in km
           type                : number
           example             : 6.814605113425086
+        latLonRect_ui        :
+          description         : the north latitude, the east longitude, the south latitude, the west longitude of the current view
+          type                : array(float[4])
+          example             : [90.0, 180.0, -90.0, -180.0]
+        latLonRect_web        :
+          description         : the north latitude, the east longitude, the south latitude, the west longitude of the current view
+          type                : array(float[4])
+          example             : [90.0, 180.0, -90.0, -180.0]
     MapFeaturesResponse :
       type                : object
       description         : List of map features


### PR DESCRIPTION
…nter

latitude linearly interpolated, delivered postion as good as center  
  
  
@albar965 new map click behavior, the left/right/top/bottom mouse click went on my nerves when "misjudging" click (despite cursor showing).  
  
I observed after many clicks and zoom changes that the api-delivered latLonRect values must have been off because centering didn't occur correctly. I assume it has something to do with marble sometimes delivering pixelated images and hence the BoundingBox might be inprecise internally.  
I tested all edge and corner ( :) literally) cases for some zoom levels from equator to norway: except on far out zoom (map repeats itself) the logic principally works.