### PR TITLE
Add range rings attach to waypoint/navaids

### DIFF
--- a/src/mapgui/mapwidget.h
+++ b/src/mapgui/mapwidget.h
@@ -160,6 +160,13 @@ public:
 
   /* Add general (red) range ring */
   void addRangeMark(const atools::geo::Pos& pos, bool showDialog);
+  void addRangeMark(const atools::geo::Pos& pos, const map::MapResult& result, bool showDialog);
+  void addRangeMark(const atools::geo::Pos& pos, const map::MapAirport *airport, const map::MapVor *vor,
+                    const map::MapNdb *ndb, const map::MapWaypoint *waypoint, const map::MapUserpoint *userpoint, bool showDialog);
+  void fillRangeMarker(map::RangeMarker& rangeMarker, const atools::geo::Pos& pos, const map::MapResult& result);
+  void fillRangeMarker(map::RangeMarker& rangeMarker, const atools::geo::Pos& pos, const map::MapAirport *airport,
+                       const map::MapVor *vor, const map::MapNdb *ndb, const map::MapWaypoint *waypoint,
+                       const map::MapUserpoint *userpoint);
 
   /* Add radio navaid range ring. Falls back to normal range rings if range is 0. */
   void addNavRangeMark(const atools::geo::Pos& pos, map::MapTypes type, const QString& displayIdent, const QString& frequency, float range);


### PR DESCRIPTION
  This PR adds new overloads for addRangeMark() and fillRangeMarker() methods that accept map objects
  (airports, navaids, waypoints, userpoints) as parameters. When adding range rings, the system now:

  - Automatically detects and attaches to map objects: When Shift+clicking on or near a waypoint, airport,
  or other map feature, range rings now snap to that feature's position and display its identifier
  - Improves user feedback: Status messages now show what the range rings are attached to (e.g., "Added
  range rings for KSEA" vs. generic "Added range rings for position")
  - Maintains backward compatibility: Original addRangeMark() method remains unchanged for existing
  functionality